### PR TITLE
Add ShellCheck

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -10,7 +10,7 @@ jobs:
    test:
       name: Lint and Test
       # We must manually provide these steps, instead of use actions and workflows in
-      # `uicpharm/workflows`, since this is a public repo and are workflows are private.
+      # `uicpharm/workflows`, since this is a public repo and our workflows are private.
       runs-on: ubuntu-latest
       steps:
          - uses: actions/checkout@v2

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -8,7 +8,7 @@
    "line-length": {
       "strict": true,
       "line_length": 90,
-      "code_block_line_length": 140,
+      "code_block_line_length": 160,
       "tables": false
    },
    "no-duplicate-header": {

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ projects, including:
      ([extension][vsc-cspell])
    - Commit message linting with [commitlint](https://commitlint.js.org)
      ([extension][vsc-commitlint])
+   - Shell script linting with [ShellCheck](https://www.shellcheck.net)
+     ([extension][vsc-shellcheck])
    - Stylesheet linting with [Stylelint](https://stylelint.io)
      ([extension][vsc-stylelint])
    - Markdown linting with [markdownlint](https://github.com/DavidAnson/markdownlint)
@@ -23,6 +25,7 @@ projects, including:
 [vsc-editorconfig]: https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig
 [vsc-eslint]: https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint
 [vsc-markdownlint]: https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint
+[vsc-shellcheck]: https://marketplace.visualstudio.com/items?itemName=timonwong.shellcheck
 [vsc-stylelint]: https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint
 
 We use these tools by setting up simple scripts that run these tests, which are
@@ -96,6 +99,19 @@ from. For example, if the commit hash was `a1b2c3d4e5`:
 ```json
 "scripts": {
    "commitlint": "commitlint --from a1b2c3d4e5",
+}
+```
+
+### Shell Script Linting
+
+[ShellCheck](https://www.shellcheck.net) will lint your shell scripts! No additional
+configuration is necessary.
+
+Add a script in `package.json` similar to this:
+
+```json
+"scripts": {
+   "shellcheck": "shellcheck **/*.sh"
 }
 ```
 
@@ -201,7 +217,7 @@ For instance, if you're using all of the tools, your scripts may look like this:
 
 ```json
 "scripts": {
-   "standards": "npm run eslint && npm run stylelint && npm run yamllint && npm run markdownlint && npm run cspell && npm run commitlint",
+   "standards": "npm run eslint && npm run stylelint && npm run shellcheck && npm run yamllint && npm run markdownlint && npm run cspell && npm run commitlint",
    "test": "npm run check-node"
 }
 ```

--- a/custom-words.txt
+++ b/custom-words.txt
@@ -1,7 +1,10 @@
 # Tech Words
 commitlint
 frontmatter
+letsencrypt
+nginxproxymanager
 nvmrc
+shellcheck
 stylelint
 stylelintrc
 vite

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
    "name": "@uicpharm/standardization",
-   "version": "0.1.1",
+   "version": "0.2.0",
    "lockfileVersion": 3,
    "requires": true,
    "packages": {
       "": {
          "name": "@uicpharm/standardization",
-         "version": "0.1.1",
+         "version": "0.2.0",
          "license": "UNLICENSED",
          "dependencies": {
             "@commitlint/cli": "17.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
             "cspell": "6.31.1",
             "eslint": "8.36.0",
             "markdownlint-cli": "0.33.0",
+            "shellcheck": "2.2.0",
             "stylelint": "14.16.1",
             "stylelint-config-standard-scss": "6.1.0",
             "stylelint-scss": "4.6.0",
@@ -1369,11 +1370,76 @@
          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
          "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
       },
+      "node_modules/base64-js": {
+         "version": "1.5.1",
+         "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+         "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+         "funding": [
+            {
+               "type": "github",
+               "url": "https://github.com/sponsors/feross"
+            },
+            {
+               "type": "patreon",
+               "url": "https://www.patreon.com/feross"
+            },
+            {
+               "type": "consulting",
+               "url": "https://feross.org/support"
+            }
+         ]
+      },
+      "node_modules/bl": {
+         "version": "1.2.3",
+         "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+         "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
+         "dependencies": {
+            "readable-stream": "^2.3.5",
+            "safe-buffer": "^5.1.1"
+         }
+      },
+      "node_modules/bl/node_modules/isarray": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+         "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+      },
+      "node_modules/bl/node_modules/readable-stream": {
+         "version": "2.3.8",
+         "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+         "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+         "dependencies": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+         }
+      },
+      "node_modules/bl/node_modules/safe-buffer": {
+         "version": "5.1.2",
+         "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+         "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      },
+      "node_modules/bl/node_modules/string_decoder": {
+         "version": "1.1.1",
+         "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+         "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+         "dependencies": {
+            "safe-buffer": "~5.1.0"
+         }
+      },
       "node_modules/boolbase": {
          "version": "1.0.0",
          "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
          "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
          "peer": true
+      },
+      "node_modules/boolean": {
+         "version": "3.2.0",
+         "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+         "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="
       },
       "node_modules/brace-expansion": {
          "version": "1.1.11",
@@ -1394,6 +1460,56 @@
          "engines": {
             "node": ">=8"
          }
+      },
+      "node_modules/buffer": {
+         "version": "5.7.1",
+         "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+         "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+         "funding": [
+            {
+               "type": "github",
+               "url": "https://github.com/sponsors/feross"
+            },
+            {
+               "type": "patreon",
+               "url": "https://www.patreon.com/feross"
+            },
+            {
+               "type": "consulting",
+               "url": "https://feross.org/support"
+            }
+         ],
+         "dependencies": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+         }
+      },
+      "node_modules/buffer-alloc": {
+         "version": "1.2.0",
+         "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+         "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+         "dependencies": {
+            "buffer-alloc-unsafe": "^1.1.0",
+            "buffer-fill": "^1.0.0"
+         }
+      },
+      "node_modules/buffer-alloc-unsafe": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+         "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+      },
+      "node_modules/buffer-crc32": {
+         "version": "0.2.13",
+         "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+         "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+         "engines": {
+            "node": "*"
+         }
+      },
+      "node_modules/buffer-fill": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+         "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ=="
       },
       "node_modules/call-bind": {
          "version": "1.0.2",
@@ -1937,6 +2053,150 @@
             "node": ">=0.10.0"
          }
       },
+      "node_modules/decompress": {
+         "version": "4.2.1",
+         "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.1.tgz",
+         "integrity": "sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==",
+         "dependencies": {
+            "decompress-tar": "^4.0.0",
+            "decompress-tarbz2": "^4.0.0",
+            "decompress-targz": "^4.0.0",
+            "decompress-unzip": "^4.0.1",
+            "graceful-fs": "^4.1.10",
+            "make-dir": "^1.0.0",
+            "pify": "^2.3.0",
+            "strip-dirs": "^2.0.0"
+         },
+         "engines": {
+            "node": ">=4"
+         }
+      },
+      "node_modules/decompress-tar": {
+         "version": "4.1.1",
+         "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
+         "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
+         "dependencies": {
+            "file-type": "^5.2.0",
+            "is-stream": "^1.1.0",
+            "tar-stream": "^1.5.2"
+         },
+         "engines": {
+            "node": ">=4"
+         }
+      },
+      "node_modules/decompress-tar/node_modules/is-stream": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+         "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+         "engines": {
+            "node": ">=0.10.0"
+         }
+      },
+      "node_modules/decompress-tarbz2": {
+         "version": "4.1.1",
+         "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
+         "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
+         "dependencies": {
+            "decompress-tar": "^4.1.0",
+            "file-type": "^6.1.0",
+            "is-stream": "^1.1.0",
+            "seek-bzip": "^1.0.5",
+            "unbzip2-stream": "^1.0.9"
+         },
+         "engines": {
+            "node": ">=4"
+         }
+      },
+      "node_modules/decompress-tarbz2/node_modules/file-type": {
+         "version": "6.2.0",
+         "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
+         "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
+         "engines": {
+            "node": ">=4"
+         }
+      },
+      "node_modules/decompress-tarbz2/node_modules/is-stream": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+         "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+         "engines": {
+            "node": ">=0.10.0"
+         }
+      },
+      "node_modules/decompress-targz": {
+         "version": "4.1.1",
+         "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
+         "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
+         "dependencies": {
+            "decompress-tar": "^4.1.1",
+            "file-type": "^5.2.0",
+            "is-stream": "^1.1.0"
+         },
+         "engines": {
+            "node": ">=4"
+         }
+      },
+      "node_modules/decompress-targz/node_modules/is-stream": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+         "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+         "engines": {
+            "node": ">=0.10.0"
+         }
+      },
+      "node_modules/decompress-unzip": {
+         "version": "4.0.1",
+         "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
+         "integrity": "sha512-1fqeluvxgnn86MOh66u8FjbtJpAFv5wgCT9Iw8rcBqQcCo5tO8eiJw7NNTrvt9n4CRBVq7CstiS922oPgyGLrw==",
+         "dependencies": {
+            "file-type": "^3.8.0",
+            "get-stream": "^2.2.0",
+            "pify": "^2.3.0",
+            "yauzl": "^2.4.2"
+         },
+         "engines": {
+            "node": ">=4"
+         }
+      },
+      "node_modules/decompress-unzip/node_modules/file-type": {
+         "version": "3.9.0",
+         "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+         "integrity": "sha512-RLoqTXE8/vPmMuTI88DAzhMYC99I8BWv7zYP4A1puo5HIjEJ5EX48ighy4ZyKMG9EDXxBgW6e++cn7d1xuFghA==",
+         "engines": {
+            "node": ">=0.10.0"
+         }
+      },
+      "node_modules/decompress-unzip/node_modules/get-stream": {
+         "version": "2.3.1",
+         "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+         "integrity": "sha512-AUGhbbemXxrZJRD5cDvKtQxLuYaIbNtDTK8YqupCI393Q2KSTreEsLUN3ZxAWFGiKTzL6nKuzfcIvieflUX9qA==",
+         "dependencies": {
+            "object-assign": "^4.0.1",
+            "pinkie-promise": "^2.0.0"
+         },
+         "engines": {
+            "node": ">=0.10.0"
+         }
+      },
+      "node_modules/decompress/node_modules/make-dir": {
+         "version": "1.3.0",
+         "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+         "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+         "dependencies": {
+            "pify": "^3.0.0"
+         },
+         "engines": {
+            "node": ">=4"
+         }
+      },
+      "node_modules/decompress/node_modules/make-dir/node_modules/pify": {
+         "version": "3.0.0",
+         "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+         "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+         "engines": {
+            "node": ">=4"
+         }
+      },
       "node_modules/deep-equal": {
          "version": "2.2.0",
          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.0.tgz",
@@ -1992,6 +2252,11 @@
             "url": "https://github.com/sponsors/ljharb"
          }
       },
+      "node_modules/detect-node": {
+         "version": "2.1.0",
+         "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+         "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
+      },
       "node_modules/diff": {
          "version": "4.0.2",
          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -2042,6 +2307,14 @@
          "version": "9.2.2",
          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+      },
+      "node_modules/end-of-stream": {
+         "version": "1.4.4",
+         "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+         "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+         "dependencies": {
+            "once": "^1.4.0"
+         }
       },
       "node_modules/entities": {
          "version": "3.0.1",
@@ -2164,6 +2437,11 @@
          "funding": {
             "url": "https://github.com/sponsors/ljharb"
          }
+      },
+      "node_modules/es6-error": {
+         "version": "4.1.1",
+         "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+         "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
       },
       "node_modules/escalade": {
          "version": "3.1.1",
@@ -2735,6 +3013,14 @@
             "reusify": "^1.0.4"
          }
       },
+      "node_modules/fd-slicer": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+         "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+         "dependencies": {
+            "pend": "~1.2.0"
+         }
+      },
       "node_modules/file-entry-cache": {
          "version": "6.0.1",
          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -2744,6 +3030,14 @@
          },
          "engines": {
             "node": "^10.12.0 || >=12.0.0"
+         }
+      },
+      "node_modules/file-type": {
+         "version": "5.2.0",
+         "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
+         "integrity": "sha512-Iq1nJ6D2+yIO4c8HHg4fyVb8mAJieo1Oloy1mLLaB2PvezNedhBVm+QU7g0qM42aiMbRXTxKKwGD17rjKNJYVQ==",
+         "engines": {
+            "node": ">=4"
          }
       },
       "node_modules/fill-range": {
@@ -2796,6 +3090,11 @@
          "dependencies": {
             "is-callable": "^1.1.3"
          }
+      },
+      "node_modules/fs-constants": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+         "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
       },
       "node_modules/fs-extra": {
          "version": "11.1.1",
@@ -2975,6 +3274,22 @@
          },
          "engines": {
             "node": ">=10"
+         }
+      },
+      "node_modules/global-agent": {
+         "version": "3.0.0",
+         "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+         "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+         "dependencies": {
+            "boolean": "^3.0.1",
+            "es6-error": "^4.1.1",
+            "matcher": "^3.0.0",
+            "roarr": "^2.15.3",
+            "semver": "^7.3.2",
+            "serialize-error": "^7.0.1"
+         },
+         "engines": {
+            "node": ">=10.0"
          }
       },
       "node_modules/global-dirs": {
@@ -3216,6 +3531,25 @@
             "node": ">=10.17.0"
          }
       },
+      "node_modules/ieee754": {
+         "version": "1.2.1",
+         "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+         "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+         "funding": [
+            {
+               "type": "github",
+               "url": "https://github.com/sponsors/feross"
+            },
+            {
+               "type": "patreon",
+               "url": "https://www.patreon.com/feross"
+            },
+            {
+               "type": "consulting",
+               "url": "https://feross.org/support"
+            }
+         ]
+      },
       "node_modules/ignore": {
          "version": "5.2.4",
          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
@@ -3452,6 +3786,11 @@
          "funding": {
             "url": "https://github.com/sponsors/ljharb"
          }
+      },
+      "node_modules/is-natural-number": {
+         "version": "4.0.1",
+         "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
+         "integrity": "sha512-Y4LTamMe0DDQIIAlaer9eKebAlDSV6huy+TWhJVPlzZh2o4tRP5SQWFlLn5N0To4mDD22/qdOq+veo1cSISLgQ=="
       },
       "node_modules/is-negative-zero": {
          "version": "2.0.2",
@@ -3705,6 +4044,11 @@
          "version": "1.0.1",
          "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
          "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
+      },
+      "node_modules/json-stringify-safe": {
+         "version": "5.0.1",
+         "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+         "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
       },
       "node_modules/json5": {
          "version": "1.0.2",
@@ -4039,6 +4383,17 @@
          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
          "dependencies": {
             "brace-expansion": "^2.0.1"
+         },
+         "engines": {
+            "node": ">=10"
+         }
+      },
+      "node_modules/matcher": {
+         "version": "3.0.0",
+         "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+         "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+         "dependencies": {
+            "escape-string-regexp": "^4.0.0"
          },
          "engines": {
             "node": ">=10"
@@ -4568,6 +4923,11 @@
             "node": ">=8"
          }
       },
+      "node_modules/pend": {
+         "version": "1.2.0",
+         "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+         "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
+      },
       "node_modules/picocolors": {
          "version": "1.0.0",
          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -4582,6 +4942,33 @@
          },
          "funding": {
             "url": "https://github.com/sponsors/jonschlinkert"
+         }
+      },
+      "node_modules/pify": {
+         "version": "2.3.0",
+         "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+         "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+         "engines": {
+            "node": ">=0.10.0"
+         }
+      },
+      "node_modules/pinkie": {
+         "version": "2.0.4",
+         "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+         "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
+         "engines": {
+            "node": ">=0.10.0"
+         }
+      },
+      "node_modules/pinkie-promise": {
+         "version": "2.0.1",
+         "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+         "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
+         "dependencies": {
+            "pinkie": "^2.0.0"
+         },
+         "engines": {
+            "node": ">=0.10.0"
          }
       },
       "node_modules/postcss": {
@@ -4677,6 +5064,11 @@
          "engines": {
             "node": ">= 0.8.0"
          }
+      },
+      "node_modules/process-nextick-args": {
+         "version": "2.0.1",
+         "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+         "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
       },
       "node_modules/prop-types": {
          "version": "15.8.1",
@@ -5002,6 +5394,22 @@
             "url": "https://github.com/sponsors/isaacs"
          }
       },
+      "node_modules/roarr": {
+         "version": "2.15.4",
+         "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+         "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+         "dependencies": {
+            "boolean": "^3.0.1",
+            "detect-node": "^2.0.4",
+            "globalthis": "^1.0.1",
+            "json-stringify-safe": "^5.0.1",
+            "semver-compare": "^1.0.0",
+            "sprintf-js": "^1.1.2"
+         },
+         "engines": {
+            "node": ">=8.0"
+         }
+      },
       "node_modules/run-con": {
          "version": "1.2.11",
          "resolved": "https://registry.npmjs.org/run-con/-/run-con-1.2.11.tgz",
@@ -5083,6 +5491,23 @@
          "resolved": "https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz",
          "integrity": "sha512-nZi59hW3Sl5P3+wOO89eHBAAGwmCPd2aE1+dLZV5MO+ItQctIvAqihzaAXIQhvtH4KJPxM080HsnqltR2y8cWg=="
       },
+      "node_modules/seek-bzip": {
+         "version": "1.0.6",
+         "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",
+         "integrity": "sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==",
+         "dependencies": {
+            "commander": "^2.8.1"
+         },
+         "bin": {
+            "seek-bunzip": "bin/seek-bunzip",
+            "seek-table": "bin/seek-bzip-table"
+         }
+      },
+      "node_modules/seek-bzip/node_modules/commander": {
+         "version": "2.20.3",
+         "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+         "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      },
       "node_modules/semver": {
          "version": "7.3.8",
          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -5095,6 +5520,36 @@
          },
          "engines": {
             "node": ">=10"
+         }
+      },
+      "node_modules/semver-compare": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+         "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="
+      },
+      "node_modules/serialize-error": {
+         "version": "7.0.1",
+         "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+         "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+         "dependencies": {
+            "type-fest": "^0.13.1"
+         },
+         "engines": {
+            "node": ">=10"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/sindresorhus"
+         }
+      },
+      "node_modules/serialize-error/node_modules/type-fest": {
+         "version": "0.13.1",
+         "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+         "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+         "engines": {
+            "node": ">=10"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/sindresorhus"
          }
       },
       "node_modules/shebang-command": {
@@ -5114,6 +5569,21 @@
          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
          "engines": {
             "node": ">=8"
+         }
+      },
+      "node_modules/shellcheck": {
+         "version": "2.2.0",
+         "resolved": "https://registry.npmjs.org/shellcheck/-/shellcheck-2.2.0.tgz",
+         "integrity": "sha512-rMt0WhmeqRrKMUqyTlkL6pd0zY27FRQMQWjQhpHMQETwG2ykc8gz+QGGtxHym4R2np646QgQAcq04sAEo3SWhA==",
+         "dependencies": {
+            "decompress": "^4.2.1",
+            "global-agent": "^3.0.0"
+         },
+         "bin": {
+            "shellcheck": "bin/shellcheck.js"
+         },
+         "engines": {
+            "node": ">=18.4.0 || >=16.17.0"
          }
       },
       "node_modules/side-channel": {
@@ -5201,6 +5671,11 @@
          "dependencies": {
             "readable-stream": "^3.0.0"
          }
+      },
+      "node_modules/sprintf-js": {
+         "version": "1.1.2",
+         "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+         "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
       },
       "node_modules/stop-iteration-iterator": {
          "version": "1.0.0",
@@ -5316,6 +5791,14 @@
          "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
          "engines": {
             "node": ">=4"
+         }
+      },
+      "node_modules/strip-dirs": {
+         "version": "2.1.0",
+         "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
+         "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
+         "dependencies": {
+            "is-natural-number": "^4.0.1"
          }
       },
       "node_modules/strip-final-newline": {
@@ -5601,6 +6084,55 @@
             "node": ">=10.0.0"
          }
       },
+      "node_modules/tar-stream": {
+         "version": "1.6.2",
+         "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+         "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+         "dependencies": {
+            "bl": "^1.0.0",
+            "buffer-alloc": "^1.2.0",
+            "end-of-stream": "^1.0.0",
+            "fs-constants": "^1.0.0",
+            "readable-stream": "^2.3.0",
+            "to-buffer": "^1.1.1",
+            "xtend": "^4.0.0"
+         },
+         "engines": {
+            "node": ">= 0.8.0"
+         }
+      },
+      "node_modules/tar-stream/node_modules/isarray": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+         "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+      },
+      "node_modules/tar-stream/node_modules/readable-stream": {
+         "version": "2.3.8",
+         "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+         "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+         "dependencies": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+         }
+      },
+      "node_modules/tar-stream/node_modules/safe-buffer": {
+         "version": "5.1.2",
+         "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+         "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      },
+      "node_modules/tar-stream/node_modules/string_decoder": {
+         "version": "1.1.1",
+         "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+         "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+         "dependencies": {
+            "safe-buffer": "~5.1.0"
+         }
+      },
       "node_modules/text-extensions": {
          "version": "1.9.0",
          "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
@@ -5626,6 +6158,11 @@
          "dependencies": {
             "readable-stream": "3"
          }
+      },
+      "node_modules/to-buffer": {
+         "version": "1.1.1",
+         "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+         "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
       },
       "node_modules/to-regex-range": {
          "version": "5.0.1",
@@ -5795,6 +6332,15 @@
          },
          "funding": {
             "url": "https://github.com/sponsors/ljharb"
+         }
+      },
+      "node_modules/unbzip2-stream": {
+         "version": "1.4.3",
+         "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+         "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+         "dependencies": {
+            "buffer": "^5.2.1",
+            "through": "^2.3.8"
          }
       },
       "node_modules/unique-string": {
@@ -6026,6 +6572,14 @@
             "node": ">=12"
          }
       },
+      "node_modules/xtend": {
+         "version": "4.0.2",
+         "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+         "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+         "engines": {
+            "node": ">=0.4"
+         }
+      },
       "node_modules/y18n": {
          "version": "5.0.8",
          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -6092,6 +6646,15 @@
          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
          "engines": {
             "node": ">=12"
+         }
+      },
+      "node_modules/yauzl": {
+         "version": "2.10.0",
+         "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+         "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+         "dependencies": {
+            "buffer-crc32": "~0.2.3",
+            "fd-slicer": "~1.1.0"
          }
       },
       "node_modules/yn": {

--- a/package.json
+++ b/package.json
@@ -4,11 +4,12 @@
    "description": "Lint and code standardization for UIC Pharmacy projects.",
    "scripts": {
       "test": "check-node-version --node 18.14.2 --npm 9.5.0",
-      "standards": "npm run eslint && npm run yamllint && npm run markdownlint && npm run stylelint && npm run cspell && npm run commitlint",
+      "standards": "npm run eslint && npm run yamllint && npm run markdownlint && npm run shellcheck && npm run stylelint && npm run cspell && npm run commitlint",
       "commitlint": "commitlint --from e4053a7754a81",
       "cspell": "cspell . --show-suggestions --no-progress",
       "eslint": "eslint .",
       "markdownlint": "markdownlint **/*.md --ignore node_modules",
+      "shellcheck": "shellcheck **/*.sh",
       "stylelint": "stylelint **/*.css **/*.scss",
       "yamllint": "yamllint .*/**/*.yml .*/**/*.yaml **/*.yml **/*.yaml"
    },
@@ -27,6 +28,7 @@
       "cspell": "6.31.1",
       "eslint": "8.36.0",
       "markdownlint-cli": "0.33.0",
+      "shellcheck": "2.2.0",
       "stylelint": "14.16.1",
       "stylelint-config-standard-scss": "6.1.0",
       "stylelint-scss": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "@uicpharm/standardization",
-   "version": "0.1.1",
+   "version": "0.2.0",
    "description": "Lint and code standardization for UIC Pharmacy projects.",
    "scripts": {
       "test": "check-node-version --node 18.14.2 --npm 9.5.0",

--- a/test/sample.sh
+++ b/test/sample.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+echo -n 'Do you want to see a random number [Y/n]: '
+read -r answer
+answer="${answer:-Y}"
+if [[ "$answer" =~ [Yy] ]]; then
+   echo How about $RANDOM?
+else
+   echo 'Ok, fine.'
+   exit
+fi


### PR DESCRIPTION
[ShellCheck](https://www.shellcheck.net) is the de facto linting tool for Linux shell scripts. The [shellcheck](https://www.npmjs.com/package/shellcheck) npm package is a wrapper for this command-line tool so that we can incorporate ShellCheck into the rest of our linting process.

Furthermore, VS Code has an [extension](https://marketplace.visualstudio.com/items?itemName=timonwong.shellcheck) as well, to round out the shell scripting experience to match the same experience we have with the rest of our standardization framework.