### PR TITLE
Refine eslint and cspell configurations

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -9,12 +9,18 @@
    ],
    "dictionaryDefinitions": [
       {
-         "name": "custom-words",
-         "description": "Custom words for UIC Pharmacy projects.",
-         "path": "./custom-words.txt"
+         "name": "uic-med-words",
+         "description": "Custom industry words for UIC Pharmacy projects.",
+         "path": "./custom-uic-med-words.txt"
+      },
+      {
+         "name": "uic-tech-words",
+         "description": "Custom tech words for UIC Pharmacy projects.",
+         "path": "./custom-uic-tech-words.txt"
       }
    ],
    "dictionaries": [
-      "custom-words"
+      "uic-med-words",
+      "uic-tech-words"
    ]
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,6 +45,7 @@ module.exports = {
             devDependencies: [
                '**/*.test.{j,t}s',
                '**/.vitepress/**/*.{j,t}s',
+               'gulpfile.*',
                'vue.config.{j,t}s',
             ],
          },

--- a/custom-uic-med-words.txt
+++ b/custom-uic-med-words.txt
@@ -1,0 +1,7 @@
+acpe
+epid
+nabp
+nasp
+pharmrep
+pharmtech
+uicpharm

--- a/custom-uic-tech-words.txt
+++ b/custom-uic-tech-words.txt
@@ -1,19 +1,34 @@
 # Tech Words
+bitnami
+bunzip
 commitlint
+curlopt
 frontmatter
+gulpfile
 letsencrypt
+moodle
+mysqldump
 nginxproxymanager
+notnull
 nvmrc
 shellcheck
 stylelint
 stylelintrc
 vite
 vitepress
+vlookup
 vuejs
-
-# UIC Vocabulary
-uicpharm
+webservice
 
 # Other typically allowable words
 avenir
+dests
+dateofbirth
+fname
+firstname
+fullname
 fullversion
+lname
+lastname
+mname
+middlename

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
    "name": "@uicpharm/standardization",
-   "version": "0.2.0",
+   "version": "0.2.1",
    "lockfileVersion": 3,
    "requires": true,
    "packages": {
       "": {
          "name": "@uicpharm/standardization",
-         "version": "0.2.0",
+         "version": "0.2.1",
          "license": "UNLICENSED",
          "dependencies": {
             "@commitlint/cli": "17.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "@uicpharm/standardization",
-   "version": "0.2.0",
+   "version": "0.2.1",
    "description": "Lint and code standardization for UIC Pharmacy projects.",
    "scripts": {
       "test": "check-node-version --node 18.14.2 --npm 9.5.0",


### PR DESCRIPTION
This is just a simple refinement of the eslint and cspell configurations:

* In eslint, the [import/no-extraneous-dependencies](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-extraneous-dependencies.md) rule is used to ensure dependencies are properly used. However, dependencies used just for build or test scripts can be in `devDependencies`. Added `gulpfile.*` as a standard exception for `devDependencies`. 
* Added more words to the cspell dictionary for typical words that may pop up. The goal is to add words that will be common to most projects but not necessarily specific to a particular project. 
* Separated the provided dictionary words into two dictionaries, a medical/industry dictionary and a tech dictionary. Also, renamed the dictionaries to start with "UIC" in the name to make them more distinguishable from a project's local custom words dictionary. This is useful in VS Code when the cspell extension offers to add words to your dictionary, to ensure you pick the right one. 