### PR TITLE
Update checkout action

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -13,7 +13,7 @@ jobs:
       # `uicpharm/workflows`, since this is a public repo and our workflows are private.
       runs-on: ubuntu-latest
       steps:
-         - uses: actions/checkout@v2
+         - uses: actions/checkout@v3
            with: { fetch-depth: 0 }
          - uses: actions/setup-node@v3
            with:


### PR DESCRIPTION
GitHub Actions has [deprecated Node 12](https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/), and [actions/checkout](https://github.com/actions/checkout) version 2 uses Node 12. Updating our build to use [v3](https://github.com/actions/checkout/blob/main/CHANGELOG.md#v300) ensures we keep current.
